### PR TITLE
Adding a fix for the carousel height issue

### DIFF
--- a/css/media-carousel.css
+++ b/css/media-carousel.css
@@ -30,8 +30,7 @@ body{
 
 /***** Carousel Card Start ****/
 .container .main-carousel {
-    transform: translateY(-25%);
-    margin-top: 2%;
+
 }
 
 .carousel-cell{
@@ -67,6 +66,7 @@ body{
     width: 80%;
     margin-right: auto;
     margin-left: auto;
+
 }
 
 .btn-outline-dark:hover {
@@ -74,5 +74,13 @@ body{
 }
 
 #media-carousel {
-    height: 100%;
+    min-height: 20rem;
+    transform: translateY(-25%);
+    margin-top: 2%;
+}
+
+.carousel-cell {
+    min-height: 420px; /* This fix includes a fix for flickity where adaptive height is not working properly 
+   So we do it ourselves by setting the min-height, ensuring that the height of a cell will be at least 420 px*/
+
 }

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     </div>
     <!-- x--- Green Background and Media heading -->
     <div class="container" id="media-carousel">
-        <div class="main-carousel" data-flickity='{ "cellAlign": "center", "contain": true, "wrapAround": true, "autoPlay": true }'>
+        <div class="main-carousel" data-flickity='{ "cellAlign": "center", "wrapAround": true, "autoPlay": true, "adaptiveHeight": true }'>
             <div class="carousel-cell">
                 <div class="card mb-2 new">
                     <img class="card-img-top rounded"
@@ -57,6 +57,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="carousel-cell">
                 <div class="card mb-2 new">
                     <img class="card-img-top rounded"
@@ -71,6 +72,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="carousel-cell">
                 <div class="card mb-2 new">
                     <img class="card-img-top rounded"
@@ -85,6 +87,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="carousel-cell">
                 <div class="card mb-2 new">
                     <img class="card-img-top rounded"


### PR DESCRIPTION
Flickity has a height set for the viewport, which unfortunately crops
the cells into a small height. This commit adds a minimum height to the
carousel cells to ensure that the height will be at least that much,
even on mobile devices hence resolving the cropping issue